### PR TITLE
Fix Next.js build by handling missing Supabase config

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,17 @@
 import { createBrowserClient } from '@supabase/ssr'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
-export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+export function createClient(): SupabaseClient | null {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('Supabase environment variables are not configured. Returning null client.')
+    }
+
+    return null
+  }
+
+  return createBrowserClient(supabaseUrl, supabaseAnonKey)
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,12 +1,22 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 
-export function createClient() {
-  const cookieStore = cookies()
+export function createClient(): SupabaseClient | null {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('Supabase environment variables are not configured. Returning null client.')
+    }
+
+    return null
+  }
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         async get(name: string) {
@@ -17,7 +27,7 @@ export function createClient() {
           const cookieStore = await cookies();
           try {
             cookieStore.set({ name, value, ...options });
-          } catch (error) {
+          } catch {
             // The `set` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing
             // user sessions.
@@ -27,7 +37,7 @@ export function createClient() {
           const cookieStore = await cookies();
           try {
             cookieStore.set({ name, value: '', ...options });
-          } catch (error) {
+          } catch {
             // The `delete` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing
             // user sessions.

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,10 +1,12 @@
 import { createClient } from 'lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
-  const cookieStore = cookies();
   const supabase = createClient();
+
+  if (!supabase) {
+    return new NextResponse('Supabase is not configured', { status: 500 });
+  }
 
   const { data: { user } } = await supabase.auth.getUser();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import { createClient } from 'lib/supabase/server';
-import { cookies } from 'next/headers';
 
 import type { ComponentProps } from 'react';
 
@@ -9,8 +8,22 @@ const Input = (props: ComponentProps<'input'>) => <input {...props} />;
 const Card = (props: ComponentProps<'div'>) => <div {...props} />;
 
 export default async function Home() {
-  const cookieStore = cookies();
   const supabase = createClient();
+
+  if (!supabase) {
+    return (
+      <div className="container mx-auto p-4">
+        <header className="text-center my-8">
+          <h1 className="text-4xl font-bold">Kapgel</h1>
+          <p className="text-lg text-gray-600">Gönder Gelsin</p>
+        </header>
+
+        <p className="text-center text-sm text-gray-500">
+          Supabase yapılandırması bulunamadığı için canlı veriler gösterilemiyor.
+        </p>
+      </div>
+    );
+  }
 
   const { data: cities } = await supabase.from('cities').select('*');
   const { data: vendors } = await supabase.from('vendors').select('*').limit(10);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
-  darkMode: ['class'],
+  darkMode: ['class', '.dark'],
   content: [
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',

--- a/workers/service-worker.ts
+++ b/workers/service-worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-declare const self: ServiceWorkerGlobalScope;
+const sw = self as unknown as ServiceWorkerGlobalScope;
 
 const CACHE_NAME = 'kapgel-cache-v1';
 const PRECACHE_URLS = [
@@ -8,15 +8,15 @@ const PRECACHE_URLS = [
   '/offline.html',
 ];
 
-self.addEventListener('install', (event) => {
+sw.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then((cache) => cache.addAll(PRECACHE_URLS))
-      .then(() => self.skipWaiting())
+      .then(() => sw.skipWaiting())
   );
 });
 
-self.addEventListener('activate', (event) => {
+sw.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((cacheNames) => {
       return Promise.all(
@@ -27,11 +27,11 @@ self.addEventListener('activate', (event) => {
         })
       );
     })
-    .then(() => self.clients.claim())
+    .then(() => sw.clients.claim())
   );
 });
 
-self.addEventListener('fetch', (event) => {
+sw.addEventListener('fetch', (event) => {
   const { request } = event;
 
   if (request.url.includes('/api/')) {


### PR DESCRIPTION
## Summary
- guard Supabase client creation when Supabase environment variables are missing and provide graceful fallbacks in the UI and API
- update dynamic routes to await Next.js 15 params, add lightweight data typing, and correct Tailwind dark mode configuration
- adjust the service worker typings so the file type-checks during builds

## Testing
- CI=1 npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dba7a56b188331b6ff749e33f646f3