### PR TITLE
Scope vendor admin RBAC to owned vendor IDs

### DIFF
--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,15 +1,37 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 export type Role = 'customer'|'vendor_admin'|'courier'|'admin'|null|undefined;
 export type Action = 'read'|'create'|'update'|'delete'|'transition';
 
 type OrderRes = { type:'order'; ownerUserId:string; vendorId?:string|null; courierId?:string|null };
 
-export function canAccess(p: {
+type CanAccessParams = {
   role: Role;
   userId?: string;
+  vendorIds?: string[];
   resource: OrderRes; // şimdilik sipariş odağı
   action: Action;
-}): boolean {
-  const { role, userId, resource, action } = p;
+};
+
+function normalizeIds(ids?: string[] | null): string[] {
+  if (!Array.isArray(ids)) return [];
+  const set = new Set<string>();
+  for (const id of ids) {
+    if (typeof id === 'string' && id.trim()) {
+      set.add(id);
+    }
+  }
+  return [...set];
+}
+
+function includesVendorId(vendorIds: string[] | undefined, vendorId: string | null | undefined): boolean {
+  if (!vendorId) return false;
+  const normalized = normalizeIds(vendorIds ?? []);
+  return normalized.includes(vendorId);
+}
+
+export function canAccess(p: CanAccessParams): boolean {
+  const { role, userId, resource, action, vendorIds } = p;
   if (role === 'admin') return true;
   if (!role) return false;
 
@@ -21,8 +43,9 @@ export function canAccess(p: {
       return false;
     }
     if (role === 'vendor_admin') {
-      // detaylı vendor eşlemesi ileride eklenecek
-      return action === 'read' || action === 'transition' || action === 'update';
+      const allowedActions: Action[] = ['read', 'transition', 'update'];
+      if (!allowedActions.includes(action)) return false;
+      return includesVendorId(vendorIds, resource.vendorId ?? null);
     }
     if (role === 'courier') {
       // sadece atandığı siparişi günceller/okur
@@ -33,4 +56,72 @@ export function canAccess(p: {
     }
   }
   return false;
+}
+
+type VendorAuthClaims = Record<string, unknown> | null | undefined;
+
+function coerceVendorIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return normalizeIds(value.filter((item): item is string => typeof item === 'string'));
+}
+
+function extractVendorIdsFromClaims(claims: VendorAuthClaims): string[] {
+  if (!claims || typeof claims !== 'object') return [];
+  const candidateObjects: Record<string, unknown>[] = [];
+  candidateObjects.push(claims as Record<string, unknown>);
+
+  const metadataLike = ['app_metadata', 'appMetadata', 'user_metadata', 'userMetadata'];
+  for (const key of metadataLike) {
+    const value = (claims as Record<string, unknown>)[key];
+    if (value && typeof value === 'object') {
+      candidateObjects.push(value as Record<string, unknown>);
+    }
+  }
+
+  const vendorKeys = ['vendor_ids', 'vendorIds', 'vendors', 'https://kapgel.com/vendor_ids'];
+  for (const obj of candidateObjects) {
+    for (const key of vendorKeys) {
+      const maybe = obj[key];
+      const parsed = coerceVendorIds(maybe);
+      if (parsed.length) return parsed;
+    }
+  }
+
+  return [];
+}
+
+export type VendorAuthContextOptions = {
+  jwtClaims?: VendorAuthClaims;
+  supabase?: Pick<SupabaseClient, 'from'>;
+  userId?: string | null;
+};
+
+type SupabaseRow = Record<string, unknown>;
+
+export async function getVendorAuthContext(options: VendorAuthContextOptions = {}): Promise<{ vendorIds: string[] }> {
+  const { jwtClaims, supabase, userId } = options;
+  const fromClaims = extractVendorIdsFromClaims(jwtClaims);
+  if (fromClaims.length) {
+    return { vendorIds: fromClaims };
+  }
+
+  if (supabase && userId) {
+    try {
+      const query = supabase
+        .from('vendors')
+        .select('id')
+        .eq('owner_user_id', userId);
+      const { data, error } = await query as unknown as { data?: SupabaseRow[] | null; error?: unknown };
+      if (!error && Array.isArray(data)) {
+        const vendorIds = data
+          .map((row) => row?.id)
+          .filter((value): value is string => typeof value === 'string' && value.length > 0);
+        return { vendorIds: normalizeIds(vendorIds) };
+      }
+    } catch (error) {
+      // ignore and fall through to empty vendor list
+    }
+  }
+
+  return { vendorIds: [] };
 }

--- a/tests/unit/rbac.spec.ts
+++ b/tests/unit/rbac.spec.ts
@@ -1,4 +1,6 @@
-import { canAccess } from "lib/rbac";
+import { describe, expect, it, vi } from "vitest";
+
+import { canAccess, getVendorAuthContext } from "lib/rbac";
 
 describe("RBAC", () => {
   it("denies access without role", () => {
@@ -19,5 +21,82 @@ describe("RBAC", () => {
       action: "read",
     });
     expect(ok).toBe(true);
+  });
+
+  it("allows vendor admin to access only matched vendor orders", () => {
+    const ok = canAccess({
+      role: "vendor_admin",
+      userId: "u2",
+      vendorIds: ["vendor-1", "vendor-2"],
+      resource: {
+        type: "order",
+        ownerUserId: "u1",
+        vendorId: "vendor-2",
+      },
+      action: "read",
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("denies vendor admin access for other vendors", () => {
+    const ok = canAccess({
+      role: "vendor_admin",
+      userId: "u2",
+      vendorIds: ["vendor-3"],
+      resource: {
+        type: "order",
+        ownerUserId: "u1",
+        vendorId: "vendor-2",
+      },
+      action: "update",
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("getVendorAuthContext", () => {
+  it("prefers vendor IDs from JWT claims", async () => {
+    const fromMock = vi.fn();
+    const ctx = await getVendorAuthContext({
+      jwtClaims: { vendor_ids: ["vendor-1", "vendor-1", "vendor-2"] },
+      supabase: { from: fromMock } as any,
+    });
+    expect(ctx.vendorIds).toEqual(["vendor-1", "vendor-2"]);
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Supabase query when claims empty", async () => {
+    const eqMock = vi.fn().mockResolvedValue({
+      data: [
+        { id: "vendor-db-1" },
+        { id: "vendor-db-2" },
+      ],
+      error: null,
+    });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const fromMock = vi.fn().mockReturnValue({ select: selectMock });
+
+    const ctx = await getVendorAuthContext({
+      supabase: { from: fromMock } as any,
+      userId: "user-1",
+    });
+
+    expect(fromMock).toHaveBeenCalledWith("vendors");
+    expect(selectMock).toHaveBeenCalledWith("id");
+    expect(eqMock).toHaveBeenCalledWith("owner_user_id", "user-1");
+    expect(ctx.vendorIds).toEqual(["vendor-db-1", "vendor-db-2"]);
+  });
+
+  it("returns empty list when no data", async () => {
+    const eqMock = vi.fn().mockResolvedValue({ data: null, error: null });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const fromMock = vi.fn().mockReturnValue({ select: selectMock });
+
+    const ctx = await getVendorAuthContext({
+      supabase: { from: fromMock } as any,
+      userId: "user-1",
+    });
+
+    expect(ctx.vendorIds).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- gate vendor admin order access by matching resource vendor IDs against the caller context
- add a helper to derive vendor IDs from JWT claims or Supabase as a fallback
- expand RBAC unit tests to cover vendor scoping and the new helper behaviour

## Testing
- npm test -- tests/unit/rbac.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc111868548331ac6fe22567f813b7