### PR TITLE
feat: load courier id in auth context

### DIFF
--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -6,10 +6,11 @@ type OrderRes = { type:'order'; ownerUserId:string; vendorId?:string|null; couri
 export function canAccess(p: {
   role: Role;
   userId?: string;
+  courierId?: string;
   resource: OrderRes; // şimdilik sipariş odağı
   action: Action;
 }): boolean {
-  const { role, userId, resource, action } = p;
+  const { role, userId, courierId, resource, action } = p;
   if (role === 'admin') return true;
   if (!role) return false;
 
@@ -26,7 +27,8 @@ export function canAccess(p: {
     }
     if (role === 'courier') {
       // sadece atandığı siparişi günceller/okur
-      const assigned = resource.courierId && userId && resource.courierId === userId;
+      const assigned =
+        resource.courierId && courierId && resource.courierId === courierId;
       if (action === 'read') return !!assigned;
       if (action === 'update' || action === 'transition') return !!assigned;
       return false;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import "./globals.css";
 import type { Metadata } from "next";
 
+import { AuthProvider } from "@/context/auth-context";
+
 export const metadata: Metadata = {
   title: { default: "Kapgel", template: "%s | Kapgel" },
   description: "Kapgel — Gönder Gelsin. Kendi kuryesi olan işletmeler ve gel-al için PWA.",
@@ -17,7 +19,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
       </head>
-      <body className="min-h-dvh bg-white text-slate-900 antialiased">{children}</body>
+      <body className="min-h-dvh bg-white text-slate-900 antialiased">
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import type { User } from '@supabase/supabase-js';
+
+import type { Role } from 'lib/rbac';
+import { createClient } from 'lib/supabase/client';
+
+export type AuthContextState = {
+  user: User | null;
+  role: Role;
+  courierId: string | null;
+  loading: boolean;
+};
+
+const AuthContext = createContext<AuthContextState | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthContextState>({
+    user: null,
+    role: null,
+    courierId: null,
+    loading: true,
+  });
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    if (!supabase) {
+      setState({ user: null, role: null, courierId: null, loading: false });
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadAuthState = async () => {
+      setState((prev) => ({ ...prev, loading: true }));
+
+      try {
+        const {
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
+
+        if (!isMounted) return;
+
+        if (userError || !user) {
+          setState({ user: null, role: null, courierId: null, loading: false });
+          return;
+        }
+
+        let role: Role = null;
+        let courierId: string | null = null;
+
+        const { data: profile, error: profileError } = await supabase
+          .from('users')
+          .select('role')
+          .eq('id', user.id)
+          .maybeSingle();
+
+        if (!isMounted) return;
+
+        if (profileError) {
+          console.error('AuthProvider: failed to load user profile', profileError);
+        }
+
+        const profileRole = (profile?.role as Role | null | undefined) ?? null;
+        role = profileRole;
+
+        if (role === 'courier') {
+          const { data: courier, error: courierError } = await supabase
+            .from('couriers')
+            .select('id')
+            .eq('user_id', user.id)
+            .maybeSingle();
+
+          if (!isMounted) return;
+
+          if (courierError) {
+            console.error('AuthProvider: failed to load courier row', courierError);
+          }
+          const courierRecordId = (courier?.id as string | null | undefined) ?? null;
+          courierId = courierRecordId;
+        }
+
+        if (!isMounted) return;
+
+        setState({ user, role, courierId, loading: false });
+      } catch (error) {
+        if (!isMounted) return;
+        console.error('AuthProvider: unexpected error', error);
+        setState({ user: null, role: null, courierId: null, loading: false });
+      }
+    };
+
+    void loadAuthState();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      void loadAuthState();
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+}

--- a/tests/unit/rbac.spec.ts
+++ b/tests/unit/rbac.spec.ts
@@ -20,4 +20,42 @@ describe("RBAC", () => {
     });
     expect(ok).toBe(true);
   });
+
+  it("allows courier to manage assigned order", () => {
+    const readOk = canAccess({
+      role: "courier",
+      courierId: "c1",
+      resource: { type: "order", ownerUserId: "u99", courierId: "c1" },
+      action: "read",
+    });
+
+    const updateOk = canAccess({
+      role: "courier",
+      courierId: "c1",
+      resource: { type: "order", ownerUserId: "u99", courierId: "c1" },
+      action: "update",
+    });
+
+    expect(readOk).toBe(true);
+    expect(updateOk).toBe(true);
+  });
+
+  it("denies courier access to unassigned order", () => {
+    const readOk = canAccess({
+      role: "courier",
+      courierId: "c1",
+      resource: { type: "order", ownerUserId: "u99", courierId: "c2" },
+      action: "read",
+    });
+
+    const transitionOk = canAccess({
+      role: "courier",
+      courierId: "c1",
+      resource: { type: "order", ownerUserId: "u99", courierId: "c2" },
+      action: "transition",
+    });
+
+    expect(readOk).toBe(false);
+    expect(transitionOk).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add an auth context provider that fetches the current user role and courier id from Supabase
- wrap the app layout with the new provider so authenticated components can access courier data
- update RBAC checks and unit tests so couriers are matched via courier ids instead of user ids

## Testing
- pnpm test:unit
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc12ddee0c83318a46704833b8bdbc