### PR TITLE
Use Supabase RPC for atomic order creation

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -30,40 +30,36 @@ export async function POST(request: Request) {
   const itemsTotal = items.reduce((acc: number, item: CartItem) => acc + item.price * item.quantity, 0);
   const total = itemsTotal; // Assuming no delivery fee for now
 
-  const { data: order, error } = await supabase
-    .from('orders')
-    .insert({
-      customer_id: user.id,
-      branch_id: branchId,
-      address_text: addressText,
-      payment_method: paymentMethod,
-      items_total: itemsTotal,
-      total: total,
-      type: 'delivery', // Assuming delivery for now
-    })
-    .select()
-    .single();
-
-  if (error) {
-    console.error('Error creating order:', error);
-    return new NextResponse('Error creating order', { status: 500 });
-  }
-
   const orderItems = items.map((item: CartItem) => ({
-    order_id: order.id,
     product_id: item.id,
     name_snapshot: item.name,
     unit_price: item.price,
     qty: item.quantity,
     total: item.price * item.quantity,
   }));
+  const { data, error } = await supabase.rpc('create_order_with_items', {
+    order_input: {
+      customer_id: user.id,
+      branch_id: branchId,
+      address_text: addressText,
+      payment_method: paymentMethod,
+      items_total: itemsTotal,
+      total,
+      type: 'delivery',
+    },
+    items_input: orderItems,
+  });
 
-  const { error: itemsError } = await supabase.from('order_items').insert(orderItems);
+  if (error) {
+    console.error('Error creating order with items:', error);
+    return new NextResponse('Failed to create order', { status: 500 });
+  }
 
-  if (itemsError) {
-    console.error('Error creating order items:', itemsError);
-    // TODO: Handle rollback
-    return new NextResponse('Error creating order items', { status: 500 });
+  const order = Array.isArray(data) ? data[0] : data;
+
+  if (!order) {
+    console.error('Supabase did not return an order payload');
+    return new NextResponse('Failed to create order', { status: 500 });
   }
 
   return NextResponse.json(order);

--- a/tests/integration/api/orders.spec.ts
+++ b/tests/integration/api/orders.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { POST } from '@/app/api/orders/route';
+
+const rpcMock = vi.hoisted(() => vi.fn());
+const getUserMock = vi.hoisted(() => vi.fn());
+const createClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock('lib/supabase/server', () => ({
+  createClient: createClientMock,
+}));
+
+const buildRequest = (body: Record<string, unknown>) =>
+  new Request('http://localhost/api/orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const basePayload = {
+  items: [
+    {
+      id: 'item-1',
+      name: 'Item 1',
+      price: 10,
+      quantity: 2,
+    },
+  ],
+  branchId: 'branch-1',
+  addressText: 'Test address',
+  paymentMethod: 'cash',
+};
+
+const expectedOrderInput = {
+  customer_id: 'user-1',
+  branch_id: basePayload.branchId,
+  address_text: basePayload.addressText,
+  payment_method: basePayload.paymentMethod,
+  items_total: 20,
+  total: 20,
+  type: 'delivery',
+};
+
+const expectedItemsInput = [
+  {
+    product_id: 'item-1',
+    name_snapshot: 'Item 1',
+    unit_price: 10,
+    qty: 2,
+    total: 20,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  getUserMock.mockResolvedValue({
+    data: {
+      user: { id: 'user-1' },
+    },
+    error: null,
+  });
+
+  createClientMock.mockReturnValue({
+    auth: { getUser: getUserMock },
+    rpc: rpcMock,
+  });
+});
+
+describe('POST /api/orders', () => {
+  it('creates an order and related items atomically via RPC', async () => {
+    const orderResponse = { id: 'order-1' };
+
+    rpcMock.mockResolvedValue({ data: orderResponse, error: null });
+
+    const response = await POST(buildRequest(basePayload));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(orderResponse);
+
+    expect(rpcMock).toHaveBeenCalledWith('create_order_with_items', {
+      order_input: expectedOrderInput,
+      items_input: expectedItemsInput,
+    });
+  });
+
+  it('returns 500 when RPC fails and surfaces an error message', async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: 'transaction failed' },
+    });
+
+    const response = await POST(buildRequest(basePayload));
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toBe('Failed to create order');
+  });
+});


### PR DESCRIPTION
## Summary
- call the `create_order_with_items` Supabase RPC to create the order and items atomically and surface clearer failure responses
- build the RPC payload with calculated totals for the order and its items
- add Vitest integration coverage that exercises successful and failed RPC scenarios via Supabase client doubles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc14328d148331b0fd53d8b4eefcd5