### PR TITLE
Add service worker caching and register in layout

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,46 @@
+const CACHE_NAME = "kapgel-cache-v1";
+const PRECACHE_URLS = ["/", "/offline.html", "/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(cacheNames.filter((name) => name !== CACHE_NAME).map((name) => caches.delete(name)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/offline.html");
+          }
+          return caches.match(event.request);
+        });
+    })
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
       </head>
-      <body className="min-h-dvh bg-white text-slate-900 antialiased">{children}</body>
+      <body className="min-h-dvh bg-white text-slate-900 antialiased">
+        {children}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/service-worker.js")
+      .catch((error) => console.error("Service worker registration failed:", error));
+  });
+}`,
+          }}
+        />
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- add a service worker with cache-first fallback to an offline page
- register the service worker from the root layout to enable PWA features

## Testing
- npm run lint
- manual verification of service worker registration in dev mode

------
https://chatgpt.com/codex/tasks/task_e_68dc1524fea4833191998a9d9d72980a