### PR TITLE
Add courier RBAC context helper

### DIFF
--- a/tests/unit/rbac.spec.ts
+++ b/tests/unit/rbac.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { canAccess, getVendorAuthContext } from "lib/rbac";
+import { canAccess, getCourierAuthContext, getVendorAuthContext } from "lib/rbac";
 
 describe("RBAC", () => {
   it("denies access without role", () => {
@@ -52,6 +52,36 @@ describe("RBAC", () => {
     });
     expect(ok).toBe(false);
   });
+
+  it("allows courier to manage assigned order", () => {
+    const ok = canAccess({
+      role: "courier",
+      userId: "courier-user", // kullanılmamalı
+      courierId: "courier-1",
+      resource: {
+        type: "order",
+        ownerUserId: "customer-1",
+        courierId: "courier-1",
+      },
+      action: "update",
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("denies courier access to unassigned order", () => {
+    const ok = canAccess({
+      role: "courier",
+      userId: "courier-user",
+      courierId: "courier-2",
+      resource: {
+        type: "order",
+        ownerUserId: "customer-1",
+        courierId: "courier-1",
+      },
+      action: "read",
+    });
+    expect(ok).toBe(false);
+  });
 });
 
 describe("getVendorAuthContext", () => {
@@ -98,5 +128,44 @@ describe("getVendorAuthContext", () => {
     });
 
     expect(ctx.vendorIds).toEqual([]);
+  });
+});
+
+describe("getCourierAuthContext", () => {
+  it("returns courier ID from Supabase", async () => {
+    const eqMock = vi.fn().mockResolvedValue({
+      data: [{ id: "courier-db-1" }],
+      error: null,
+    });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const fromMock = vi.fn().mockReturnValue({ select: selectMock });
+
+    const ctx = await getCourierAuthContext({
+      supabase: { from: fromMock } as any,
+      userId: "user-1",
+    });
+
+    expect(fromMock).toHaveBeenCalledWith("couriers");
+    expect(selectMock).toHaveBeenCalledWith("id");
+    expect(eqMock).toHaveBeenCalledWith("user_id", "user-1");
+    expect(ctx.courierId).toBe("courier-db-1");
+  });
+
+  it("returns null when courier not found", async () => {
+    const eqMock = vi.fn().mockResolvedValue({ data: [], error: null });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const fromMock = vi.fn().mockReturnValue({ select: selectMock });
+
+    const ctx = await getCourierAuthContext({
+      supabase: { from: fromMock } as any,
+      userId: "user-1",
+    });
+
+    expect(ctx.courierId).toBeNull();
+  });
+
+  it("returns null without Supabase client or user ID", async () => {
+    const ctx = await getCourierAuthContext();
+    expect(ctx.courierId).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- update courier RBAC checks to rely on courierId from the auth context
- add a helper that loads the courier id for the authenticated user from Supabase
- extend unit tests to cover courier scenarios and the new courier auth context helper

## Testing
- npm run test -- tests/unit/rbac.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc20aecde88331bcdce427c5c03675