### PR TITLE
feat: add transactional order creation RPC

### DIFF
--- a/db/migrations/0001_create_order_with_items.sql
+++ b/db/migrations/0001_create_order_with_items.sql
@@ -1,0 +1,82 @@
+CREATE OR REPLACE FUNCTION public.create_order_with_items(
+  order_input jsonb,
+  items_input jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_order orders;
+  inserted_items jsonb := '[]'::jsonb;
+  order_items_total numeric := COALESCE((order_input->>'items_total')::numeric, 0);
+  order_total numeric := COALESCE((order_input->>'total')::numeric, 0);
+  order_delivery_fee numeric := COALESCE((order_input->>'delivery_fee')::numeric, 0);
+BEGIN
+  IF order_input IS NULL THEN
+    RAISE EXCEPTION 'order_input cannot be null';
+  END IF;
+
+  IF items_input IS NULL OR jsonb_typeof(items_input) <> 'array' OR jsonb_array_length(items_input) = 0 THEN
+    RAISE EXCEPTION 'items_input must be a non-empty array';
+  END IF;
+
+  INSERT INTO orders (
+    customer_id,
+    branch_id,
+    courier_id,
+    address_text,
+    geo_point,
+    payment_method,
+    items_total,
+    delivery_fee,
+    total,
+    type
+  )
+  VALUES (
+    (order_input->>'customer_id')::uuid,
+    (order_input->>'branch_id')::uuid,
+    NULLIF(order_input->>'courier_id', '')::uuid,
+    order_input->>'address_text',
+    order_input->>'geo_point',
+    (order_input->>'payment_method')::payment_method,
+    order_items_total,
+    order_delivery_fee,
+    order_total,
+    (order_input->>'type')::order_type
+  )
+  RETURNING * INTO new_order;
+
+  WITH inserted AS (
+    INSERT INTO order_items (
+      order_id,
+      product_id,
+      name_snapshot,
+      unit_price,
+      qty,
+      total
+    )
+    SELECT
+      new_order.id,
+      (item->>'product_id')::uuid,
+      item->>'name_snapshot',
+      (item->>'unit_price')::numeric,
+      (item->>'qty')::integer,
+      (item->>'total')::numeric
+    FROM jsonb_array_elements(items_input) AS item
+    RETURNING *
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(inserted)), '[]'::jsonb)
+  INTO inserted_items
+  FROM inserted;
+
+  RETURN jsonb_build_object(
+    'order', to_jsonb(new_order),
+    'items', inserted_items
+  );
+EXCEPTION
+  WHEN others THEN
+    RAISE;
+END;
+$$;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1759173991070,
       "tag": "0000_strong_martin_li",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759173992070,
+      "tag": "0001_create_order_with_items",
+      "breakpoints": false
     }
   ]
 }

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -52,7 +52,8 @@ export async function POST(request: Request) {
 
   if (error) {
     console.error('Error creating order with items:', error);
-    return new NextResponse('Failed to create order', { status: 500 });
+    const errorMessage = error.message || 'Failed to create order';
+    return new NextResponse(errorMessage, { status: 500 });
   }
 
   const order = Array.isArray(data) ? data[0] : data;

--- a/tests/integration/api/orders.spec.ts
+++ b/tests/integration/api/orders.spec.ts
@@ -83,6 +83,30 @@ describe('POST /api/orders', () => {
     });
   });
 
+  it('returns the payload from Supabase with the newly created order and items', async () => {
+    const supabasePayload = {
+      order: {
+        id: 'order-1',
+        customer_id: 'user-1',
+      },
+      items: [
+        {
+          id: 'order-item-1',
+          order_id: 'order-1',
+          product_id: 'item-1',
+          qty: 2,
+        },
+      ],
+    };
+
+    rpcMock.mockResolvedValue({ data: supabasePayload, error: null });
+
+    const response = await POST(buildRequest(basePayload));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(supabasePayload);
+  });
+
   it('returns 500 when RPC fails and surfaces an error message', async () => {
     rpcMock.mockResolvedValue({
       data: null,
@@ -92,6 +116,6 @@ describe('POST /api/orders', () => {
     const response = await POST(buildRequest(basePayload));
 
     expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toBe('Failed to create order');
+    await expect(response.text()).resolves.toBe('transaction failed');
   });
 });


### PR DESCRIPTION
## Summary
- add a migration defining the `create_order_with_items` function to insert orders and order items atomically
- update the orders API endpoint to surface Supabase RPC error messages directly
- extend the integration tests to cover the RPC payload shape and error propagation

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc21d111ec8331952a5e6f3f368f52