### PR TITLE
Harden create_order_with_items against customer spoofing

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -14,10 +14,25 @@ export async function POST(request: Request) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
-  const { items, branchId, addressText, paymentMethod } = await request.json();
+  const {
+    items,
+    branchId,
+    addressText,
+    paymentMethod,
+    customerId,
+    courierId,
+  } = await request.json();
 
   if (!items || !branchId || !addressText || !paymentMethod) {
     return new NextResponse('Missing required fields', { status: 400 });
+  }
+
+  if (customerId && customerId !== user.id) {
+    return new NextResponse('Customer ID mismatch', { status: 403 });
+  }
+
+  if (courierId) {
+    return new NextResponse('Customers cannot assign courier', { status: 403 });
   }
 
   interface CartItem {

--- a/tests/integration/api/orders.spec.ts
+++ b/tests/integration/api/orders.spec.ts
@@ -118,4 +118,30 @@ describe('POST /api/orders', () => {
     expect(response.status).toBe(500);
     await expect(response.text()).resolves.toBe('transaction failed');
   });
+
+  it('rejects requests when payload customerId mismatches the authenticated user', async () => {
+    const response = await POST(
+      buildRequest({
+        ...basePayload,
+        customerId: 'someone-else',
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('Customer ID mismatch');
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests attempting to assign a courier directly', async () => {
+    const response = await POST(
+      buildRequest({
+        ...basePayload,
+        courierId: 'courier-1',
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('Customers cannot assign courier');
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- enforce customer identity via auth.uid() in the create_order_with_items RPC and block unauthorized courier assignment
- surface the hardened logic in the schema reflection and API handler while validating incoming payloads
- extend integration and Supabase security tests to cover customer/courier spoofing scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc37e8e47483318ed1406b31b87450