### PR TITLE
Add RLS policies and tests for order items access

### DIFF
--- a/db/rls.sql
+++ b/db/rls.sql
@@ -75,7 +75,40 @@ CREATE POLICY "Vendor admins can delete their branch orders" ON orders FOR DELET
       AND v.owner_user_id = auth.uid()
   )
 );
-CREATE POLICY "Couriers can view their assigned orders" ON orders FOR SELECT USING (courier_id = (SELECT id FROM couriers WHERE user_id = auth.uid()));
+CREATE POLICY "Couriers can view their assigned orders" ON orders FOR SELECT USING (
+  courier_id = (SELECT id FROM couriers WHERE user_id = auth.uid())
+);
+
+-- ORDER ITEMS
+CREATE POLICY "Customers can view their order items" ON order_items FOR SELECT USING (
+  EXISTS (
+    SELECT 1
+    FROM orders o
+    WHERE o.id = order_id
+      AND o.customer_id = auth.uid()
+  )
+);
+
+CREATE POLICY "Vendor admins can view their branch order items" ON order_items FOR SELECT USING (
+  EXISTS (
+    SELECT 1
+    FROM orders o
+    JOIN branches b ON b.id = o.branch_id
+    JOIN vendors v ON v.id = b.vendor_id
+    WHERE o.id = order_id
+      AND v.owner_user_id = auth.uid()
+  )
+);
+
+CREATE POLICY "Couriers can view their assigned order items" ON order_items FOR SELECT USING (
+  EXISTS (
+    SELECT 1
+    FROM orders o
+    JOIN couriers c ON c.id = o.courier_id
+    WHERE o.id = order_id
+      AND c.user_id = auth.uid()
+  )
+);
 
 -- COURIERS
 CREATE POLICY "Vendor admins can manage their couriers" ON couriers FOR ALL USING (

--- a/supabase/migrations/20250204000200_functions_and_policies.sql
+++ b/supabase/migrations/20250204000200_functions_and_policies.sql
@@ -182,6 +182,36 @@ create policy "Couriers can view their assigned orders" on public.orders for sel
   )
 );
 
+create policy "Customers can view their order items" on public.order_items for select using (
+  exists (
+    select 1
+    from public.orders o
+    where o.id = order_id
+      and o.customer_id = auth.uid()
+  )
+);
+
+create policy "Vendor admins can view their branch order items" on public.order_items for select using (
+  exists (
+    select 1
+    from public.orders o
+    join public.branches b on b.id = o.branch_id
+    join public.vendors v on v.id = b.vendor_id
+    where o.id = order_id
+      and v.owner_user_id = auth.uid()
+  )
+);
+
+create policy "Couriers can view their assigned order items" on public.order_items for select using (
+  exists (
+    select 1
+    from public.orders o
+    join public.couriers c on c.id = o.courier_id
+    where o.id = order_id
+      and c.user_id = auth.uid()
+  )
+);
+
 create policy "Vendor admins can manage their couriers" on public.couriers for all using (
   vendor_id = (
     select vendor_id from public.branches where id in (


### PR DESCRIPTION
## Summary
- add customer, vendor admin, and courier row level select policies for order_items based on related orders
- synchronize the standalone RLS reference script with the new order_items policies
- expand the Supabase RLS tests to cover order_items visibility for customers, vendor admins, and couriers

## Testing
- `pnpm vitest tests/unit/supabase-rls-orders.spec.ts --run`
- `npx supabase migration up`


------
https://chatgpt.com/codex/tasks/task_e_68dc3f417fa48331b5391ad49fd2b718