### PR TITLE
Fix mock session cookies for Next.js 15

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,8 +51,8 @@ type SessionDescriptor = {
   resolvedRole: PrimaryRole | null;
 };
 
-function resolveMockSession(): SessionDescriptor | null {
-  const cookieStore = cookies();
+async function resolveMockSession(): Promise<SessionDescriptor | null> {
+  const cookieStore = await cookies();
   const mockRole = cookieStore.get('x-mock-role')?.value;
   const email = cookieStore.get('x-mock-email')?.value ?? null;
 
@@ -76,7 +76,7 @@ async function loadLandingData() {
   const supabase = createClient();
 
   if (!supabase) {
-    const mockSession = resolveMockSession();
+    const mockSession = await resolveMockSession();
     return {
       cities: FALLBACK_CITIES,
       vendors: FALLBACK_VENDORS,
@@ -118,7 +118,7 @@ async function loadLandingData() {
   const roleMetadata = extractRoleMetadata(sessionUser);
   const { target, needsOnboarding, role } = resolveRoleRedirect(roleMetadata);
 
-  const mockSession = !sessionUser ? resolveMockSession() : null;
+  const mockSession = !sessionUser ? await resolveMockSession() : null;
 
   return {
     cities: cities.length > 0 ? cities : FALLBACK_CITIES,


### PR DESCRIPTION
## Summary
- await `cookies()` when resolving mock sessions to match the updated Next.js 15 API
- ensure landing data loader awaits the mock session helper before constructing responses

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e14e8b11448331a6c9eacf02f0cf30